### PR TITLE
Support custom lhttpc options & safer setup call

### DIFF
--- a/include/dinerl_types.hrl
+++ b/include/dinerl_types.hrl
@@ -1,6 +1,7 @@
 -type access_key_id() :: string().
 -type secret_access_key() :: string().
 -type zone() :: string().
+-type options() :: list().
 -type token() :: string().
 -type rfcdate() :: string().
 -type endpoint() :: string().
@@ -15,7 +16,7 @@
 
 -type jsonf() :: any().
 
--type clientarguments() :: {access_key_id(), secret_access_key(), zone(), token(), rfcdate(), integer()}.
+-type clientarguments() :: {access_key_id(), secret_access_key(), zone(), options(), token(), rfcdate(), integer()}.
 
 -type method() :: batch_get_item | get_item | put_item | delete_item |
                   update_item | create_table | list_tables | describe_table |

--- a/src/dinerl.erl
+++ b/src/dinerl.erl
@@ -21,12 +21,17 @@ setup(AccessKeyId, SecretAccessKey, Zone) ->
     setup(AccessKeyId, SecretAccessKey, Zone, [{max_connections, 5000}]).
 
 -spec setup(access_key_id(), secret_access_key(), zone(), options()) ->
-                   {ok, clientarguments()}.
+                   {ok, clientarguments()} | {error, any()}.
 setup(AccessKeyId, SecretAccessKey, Zone, Options) ->
     ets:new(?DINERL_DATA, [named_table, public]),
-    R = update_data(AccessKeyId, SecretAccessKey, Zone, Options),
-    timer:apply_interval(1000, ?MODULE, update_data, [AccessKeyId, SecretAccessKey, Zone, Options]),
-    R.
+    case update_data(AccessKeyId, SecretAccessKey, Zone, Options) of
+        {ok, ClientArgs} ->
+            case timer:apply_interval(1000, ?MODULE, update_data, [AccessKeyId, SecretAccessKey, Zone, Options]) of
+                {ok, _TRef} -> {ok, ClientArgs};
+                Error -> Error
+            end;
+        Error -> Error
+    end.
 
 
 -spec api(method()) ->result().

--- a/src/dinerl_client.erl
+++ b/src/dinerl_client.erl
@@ -3,11 +3,11 @@
 
 -include("dinerl_types.hrl").
 
--export([api/7, api/8]).
+-export([api/7, api/8, api/9]).
 
 %%
 %% Item related operations
-%% 
+%%
 -spec method_name(method()) -> string().
 method_name(batch_get_item) ->
     "DynamoDBv20110924.BatchGetItem";
@@ -46,13 +46,18 @@ method_name(scan) ->
 -spec api(access_key_id(), secret_access_key(), zone(),
           token(), rfcdate(), method(), any()) -> result().
 api(AccessKeyId, SecretAccessKey, Zone, Token, RFCDate, Name, Body) ->
-    api(AccessKeyId, SecretAccessKey, Zone, Token, RFCDate, Name, Body, undefined).
+    api(AccessKeyId, SecretAccessKey, Zone, Token, RFCDate, Name, Body, undefined, []).
 
 -spec api(access_key_id(), secret_access_key(), zone(),
           token(), rfcdate(), method(), any(), integer()) -> result().
 api(AccessKeyId, SecretAccessKey, Zone, Token, RFCDate, Name, Body, Timeout) ->
+    api(AccessKeyId, SecretAccessKey, Zone, Token, RFCDate, Name, Body, Timeout, []).
+
+-spec api(access_key_id(), secret_access_key(), zone(),
+          token(), rfcdate(), method(), any(), integer(), options()) -> result().
+api(AccessKeyId, SecretAccessKey, Zone, Token, RFCDate, Name, Body, Timeout, Options) ->
     case dynamodb:call(AccessKeyId, SecretAccessKey, Zone, method_name(Name),
-                       Token, RFCDate, dmochijson2:encode(Body), Timeout) of
+                       Token, RFCDate, dmochijson2:encode(Body), Timeout, Options) of
         {ok, Response} ->
             {ok, dmochijson2:decode(Response)};
         {error, Code, Reason} ->


### PR DESCRIPTION
I wanted to use dinerl with the "regular" esl-lhttpc version, but ran into the problem that only ferd's fork supports the the `{max_connections, n}` option that was hardcoded in the request code of dinerl.

I suggest to offer a `dinerl:setup/4` function that let's the user override the lhttpc options (I left the default options as is when using `dinerl:setup/3`). While working on the setup call, I also added some checks to make sure that setup only starts the periodic timer when the initial `updata_data` actually succeeds.

Please note: the `clientarguments()` returned by a successful call to setup will now contain an additional element with the lhttpc options. If changing the return signature is a problem for you, I can also make it match the original tuple.
