### PR TITLE
Add lhttpc to applications section.

### DIFF
--- a/src/dinerl.app.src
+++ b/src/dinerl.app.src
@@ -5,4 +5,4 @@
   {modules, []},
   {registered, []},
   {env, []},
-  {applications, [kernel, stdlib, crypto, inets, asn1, public_key, ssl, xmerl]}]}.
+  {applications, [kernel, stdlib, crypto, inets, asn1, public_key, ssl, xmerl, lhttpc]}]}.


### PR DESCRIPTION
Add `lhttpc` to `applications` section so `dinerl` could be properly started with
releases and/or `application:ensure_all_started/1`.

Without this fix `lhttpc` is not started, so whenever I do, say `dinerl:list_tables/0`
I got:

``` erlang
13> dinerl:list_tables().                                                                                   
** exception exit: {badarg,[{ets,lookup,
                                 [lhttpc_lb,{"dynamodb.us-west-2.amazonaws.com",80,false}],
                                 []},
                            {lhttpc_lb,find_lb,2,
                                       [{file,"src/lhttpc_lb.erl"},{line,171}]},
                            {lhttpc_lb,checkout,5,
                                       [{file,"src/lhttpc_lb.erl"},{line,39}]},
                            {lhttpc_client,execute,10,
                                           [{file,"src/lhttpc_client.erl"},{line,110}]},
                            {lhttpc_client,request,10,
                                           [{file,"src/lhttpc_client.erl"},{line,82}]}]}
     in function  lhttpc:request/9 (src/lhttpc.erl, line 347)
     in call from dynamodb:submit/4 (src/dynamodb.erl, line 64)
     in call from dinerl_client:api/8 (src/dinerl_client.erl, line 56)
```
