### PR TITLE
Fix compiler warnings.

### DIFF
--- a/src/awsrequest.erl
+++ b/src/awsrequest.erl
@@ -12,7 +12,7 @@ add_sign(AccessKeyId, SecretAccessKey, HostUrl, Method, ArgList) ->
 
     EncodedUrlParams = urlencode(lists:keysort(1, lists:merge(UrlParams, ArgList))),
     SignString = [Method, $\n, HostUrl, $\n, Path, $\n, EncodedUrlParams],
-    Signature = base64:encode_to_string(crypto:sha_mac(SecretAccessKey, SignString)),
+    Signature = base64:encode_to_string(crypto:hmac(sha, SecretAccessKey, SignString)),
     EncodedUrlParams ++ "&Signature=" ++ quote_plus(Signature).
 
 get_timestamp(new) ->

--- a/src/dinerl.erl
+++ b/src/dinerl.erl
@@ -209,13 +209,6 @@ update_item(T, K, [{return, all_new}|Rest], Acc, Timeout) ->
 update_item(T, K, [{return, updated_new}|Rest], Acc, Timeout) ->
     update_item(T, K, Rest, [{<<"ReturnValues">>, ?UPDATED_NEW}|Acc], Timeout).
 
-
-
-
-scan() ->
-    pass.
-
-
 %% query_item options:
 %% limit: int, max number of results
 %% count: bool, only return the total count


### PR DESCRIPTION
Largely around the renames in the crypto module. All cryptographic
cipher preferences are preserved.

Signed-off-by: Brian L. Troutwine <brian.troutwine@adroll.com>