### PR TITLE
Add support for update expressions

### DIFF
--- a/src/dinerl.erl
+++ b/src/dinerl.erl
@@ -203,19 +203,26 @@ do_get_items([{Table, Keys, Options}|Rest], Acc, Timeout, Region) ->
 
 
 update_item_with_expression(TableName, Key, UpdateExpression, ExpressionAttributeValues, ReturnValues, Acc, Timeout) ->
+    MandatoryParams = [
+        {<<"TableName">>, TableName},
+        {<<"Key">>, Key},
+        {<<"UpdateExpression">>, UpdateExpression}
+    ],
+    OptionalParams = [
+        {<<"ExpressionAttributeValues">>, ExpressionAttributeValues},
+        {<<"ReturnValues">>, ReturnValues}
+    ],
+    DefinedOptionalParams = lists:filter(fun ({_, undefined}) ->
+        false;
+        (_) ->
+            true
+    end, OptionalParams),
+
     api(
         update_item,
-        [
-            {<<"TableName">>, TableName},
-            {<<"Key">>, Key},
-            {<<"UpdateExpression">>, UpdateExpression},
-            {<<"ExpressionAttributeValues">>, ExpressionAttributeValues},
-            {<<"ReturnValues">>, ReturnValues}
-            | Acc
-        ],
+        MandatoryParams ++ DefinedOptionalParams ++ Acc,
         Timeout
-    )
-.
+    ).
 
 
 update_item(Table, Key, Options) ->

--- a/src/dinerl.erl
+++ b/src/dinerl.erl
@@ -15,6 +15,10 @@
 -export([get_item/3, get_item/4, get_item/5]).
 -export([get_items/1, get_items/2, get_items/3, get_items/4, get_items/5]).
 -export([update_item/3, update_item/4]).
+-export([update_item_with_expression/3]).
+-export([update_item_with_expression/4]).
+-export([update_item_with_expression/5]).
+-export([update_item_with_expression/6]).
 -export([update_item_with_expression/7]).
 -export([query_item/3, query_item/4, query_item/5]).
 -export([query/2, query/3, query/4]).
@@ -201,6 +205,18 @@ do_get_items([{Table, Keys, Options}|Rest], Acc, Timeout, Region) ->
     Attrs = proplists:get_value(attrs, Options, []),
     do_get_items(Rest, [{Table, [{<<"Keys">>, Keys}, {<<"AttributesToGet">>, Attrs}]} | Acc], Timeout, Region).
 
+
+update_item_with_expression(TableName, Key, UpdateExpression) ->
+    update_item_with_expression(TableName, Key, UpdateExpression, undefined, <<"NONE">>, [], undefined).
+
+update_item_with_expression(TableName, Key, UpdateExpression, ExpressionAttributeValues) ->
+    update_item_with_expression(TableName, Key, UpdateExpression, ExpressionAttributeValues, <<"NONE">>, [], undefined).
+
+update_item_with_expression(TableName, Key, UpdateExpression, ExpressionAttributeValues, ReturnValues) ->
+    update_item_with_expression(TableName, Key, UpdateExpression, ExpressionAttributeValues, ReturnValues, [], undefined).
+
+update_item_with_expression(TableName, Key, UpdateExpression, ExpressionAttributeValues, ReturnValues, Acc) ->
+    update_item_with_expression(TableName, Key, UpdateExpression, ExpressionAttributeValues, ReturnValues, Acc, undefined).
 
 update_item_with_expression(TableName, Key, UpdateExpression, ExpressionAttributeValues, ReturnValues, Acc, Timeout) ->
     MandatoryParams = [

--- a/src/dinerl.erl
+++ b/src/dinerl.erl
@@ -15,6 +15,7 @@
 -export([get_item/3, get_item/4, get_item/5]).
 -export([get_items/1, get_items/2, get_items/3, get_items/4, get_items/5]).
 -export([update_item/3, update_item/4]).
+-export([update_item_with_expression/7]).
 -export([query_item/3, query_item/4, query_item/5]).
 -export([query/2, query/3, query/4]).
 
@@ -201,6 +202,20 @@ do_get_items([{Table, Keys, Options}|Rest], Acc, Timeout, Region) ->
     do_get_items(Rest, [{Table, [{<<"Keys">>, Keys}, {<<"AttributesToGet">>, Attrs}]} | Acc], Timeout, Region).
 
 
+update_item_with_expression(TableName, Key, UpdateExpression, ExpressionAttributeValues, ReturnValues, Acc, Timeout) ->
+    api(
+        update_item,
+        [
+            {<<"TableName">>, TableName},
+            {<<"Key">>, Key},
+            {<<"UpdateExpression">>, UpdateExpression},
+            {<<"ExpressionAttributeValues">>, ExpressionAttributeValues},
+            {<<"ReturnValues">>, ReturnValues}
+            | Acc
+        ],
+        Timeout
+    )
+.
 
 
 update_item(Table, Key, Options) ->

--- a/src/dinerl_client.erl
+++ b/src/dinerl_client.erl
@@ -20,7 +20,7 @@ method_name(put_item) ->
 method_name(delete_item) ->
     "DynamoDB_20111205.DeleteItem";
 method_name(update_item) ->
-    "DynamoDB_20111205.UpdateItem";
+    "DynamoDB_20120810.UpdateItem";
 
 %%
 %% Table related operations


### PR DESCRIPTION
We need to use "update expressions" on DynamoDB, to take advantage of the list API.

- [x] update API version (DynamoDB_20111205 -> DynamoDB_20120810)
- [x] make sure change on API version do not breaks existing apps (confirmed: new low-level API version is backward compatible)
- [x] implement function
- [x] make function return values returned from DynamoDB

@dialtone @byyo @nishapunjabi @knutin 