### PR TITLE
Add IndexName parameter

### DIFF
--- a/src/dinerl.erl
+++ b/src/dinerl.erl
@@ -295,6 +295,8 @@ convert_query_parameters([{limit, V}|Rest], Acc) ->
     convert_query_parameters(Rest, [{<<"Limit">>, V} | Acc]);
 convert_query_parameters([{count, V}|Rest], Acc) ->
     convert_query_parameters(Rest, [{<<"Count">>, V} | Acc]);
+convert_query_parameters([{index_name, IndexName} | Rest], Acc) ->
+    convert_query_parameters(Rest, [{<<"IndexName">>, IndexName} | Acc]);
 convert_query_parameters([{scan_index_forward, V}|Rest], Acc) ->
     convert_query_parameters(Rest, [{<<"ScanIndexForward">>, V} | Acc]);
 convert_query_parameters([{consistent, V}|Rest], Acc) ->


### PR DESCRIPTION
Add missing `IndexName` parameter according to http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-IndexName