### PR TITLE
LIQ-5217 remove AttributesToGet from body request to get all attrs

### DIFF
--- a/src/dinerl.erl
+++ b/src/dinerl.erl
@@ -179,8 +179,6 @@ get_item(T, K, [{attrs, V}|Rest], Acc, Timeout, Region) ->
     get_item(T, K, Rest, [{<<"AttributesToGet">>, V} | Acc], Timeout, Region).
 
 
-
-
 get_items(Table, Keys, Options) ->
     do_get_items([{Table, Keys, Options}], [], undefined, undefined).
 get_items(Table, Keys, Options, Timeout) ->
@@ -196,7 +194,12 @@ do_get_items([], Acc, Timeout, Region) ->
     api(batch_get_item, [{<<"RequestItems">>, Acc}], Timeout, Region);
 do_get_items([{Table, Keys, Options}|Rest], Acc, Timeout, Region) ->
     Attrs = proplists:get_value(attrs, Options, []),
-    do_get_items(Rest, [{Table, [{<<"Keys">>, Keys}, {<<"AttributesToGet">>, Attrs}]} | Acc], Timeout, Region).
+    do_get_items(Rest, [get_body_request(Table, Keys, Attrs) | Acc], Timeout, Region).
+
+get_body_request(Table, Keys, []) ->
+    {Table, [{<<"Keys">>, Keys}]};
+get_body_request(Table, Keys, Attrs) ->
+    {Table, [{<<"Keys">>, Keys}, {<<"AttributesToGet">>, Attrs}]}.
 
 
 update_item_with_expression(TableName, Key, UpdateExpression) ->


### PR DESCRIPTION
Ticket -> https://adroll.atlassian.net/browse/LIQ-5217

Changed dinerl:get_items(...) to remove AttributesToGet from body request when the attributes list is empty to get all fields of the table. Before the changing, if Options receives an empty list it throws an error:

`{error,"Bad Request",<<"{\"__type\":\"com.amazon.coral.validate#ValidationException\",\"message\":\"1 validation error detected: Value '[]' at 'requestItems.ProductDataTest.member.attributesToGet' failed to satisfy constraint: Member must have length greater than or equal to 1\"}">>}`

Since trecs needs to return all fields from the ProductData table in DynamoDB, we can´t specify one by one, dinerl:get_items was changed to deal with empty lists in this case to return those fields.