### PR TITLE
SRE-1994 s3-http-domain

### DIFF
--- a/.buildkite/pipelines/dinerl-pr-builder/start.yml
+++ b/.buildkite/pipelines/dinerl-pr-builder/start.yml
@@ -1,7 +1,7 @@
 - label: 'Test Build'
   command:
     - if [ ! -z "$MERGE_BRANCH" ]; then git merge $MERGE_BRANCH -m "merging $MERGE_BRANCH"; fi
-    - curl https://s3.amazonaws.com/rebar3/rebar3 -o ./rebar3
+    - curl https://rebar3.s3.amazonaws.com/rebar3 -o ./rebar3
     - chmod +x rebar3
     - aws s3 sync s3://adroll-misc/rtb/dinerl/ . --exclude "*" --include "*.plt" --no-follow-symlinks
     - REBAR=./rebar3 make test


### PR DESCRIPTION
**Summary**
Updated the Amazon S3 Path, as the current s3 HTTP domain is getting [deprecated](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/)

**Related Ticket**
https://adroll.atlassian.net/browse/SRE-1994