### PR TITLE
Support for expression attribute names

### DIFF
--- a/src/dinerl.erl
+++ b/src/dinerl.erl
@@ -321,7 +321,9 @@ convert_query_parameters([{condition_expression, KeyConditionExpression} | Rest]
 convert_query_parameters([{filter_expression, KeyConditionExpression} | Rest], Acc) ->
     convert_query_parameters(Rest, [{<<"FilterExpression">>, KeyConditionExpression} | Acc]);
 convert_query_parameters([{expression_attribute_values, ExpressionAttributeValues} | Rest], Acc) ->
-    convert_query_parameters(Rest, [{<<"ExpressionAttributeValues">>, ExpressionAttributeValues} | Acc]).
+    convert_query_parameters(Rest, [{<<"ExpressionAttributeValues">>, ExpressionAttributeValues} | Acc]);
+convert_query_parameters([{expression_attribute_names, ExpressionAttributeNames} | Rest], Acc) ->
+    convert_query_parameters(Rest, [{<<"ExpressionAttributeNames">>, ExpressionAttributeNames} | Acc]).
 
 batch_write_item(TableName, PutItems, DeleteKeys) ->
     api(batch_write_item, [{<<"RequestItems">>, [


### PR DESCRIPTION
There are reserved words on DynamoDB, that can't be used directly on on queries/projection, in those cases they must be defined as a expression-attribute-name and then referenced.

Ref:
https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html

Sample usage:
(for filtering over column  type=SomeType ,  `type` is a reserved word):

```
DinerlQuery = [{expression_attribute_values, [ {":type", [{"S", <<"SomeType">>}]} ]},
               {expression_attribute_names, [{"#t",  <<"type">>}]},
               {filter_expression, <<"#t = :type">>},
               ...
               ]
```