### PR TITLE
fix elvis.config file

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -7,10 +7,12 @@
         filter => "*.erl",
         ruleset => erl_files,
         rules => [
-            {elvis_style, line_length, #{limit => 120}},
+            {elvis_text_style, line_length, #{limit => 120}},
             {elvis_style, god_modules, #{limit => 50}},
             {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
-            {elvis_style, nesting_level, #{level => 4}}
+            {elvis_style, nesting_level, #{level => 4}},
+            {elvis_style, atom_naming_convention, disable},
+            {elvis_style, macro_names, disable}
         ]
       }
      ]
@@ -18,3 +20,4 @@
    ]
  }
 ].
+

--- a/rebar.config
+++ b/rebar.config
@@ -44,4 +44,4 @@
 
 {format, [{files, ["src/*.erl", "include/*.hrl"]}]}.
 
-{alias, [{test, [format, xref, dialyzer, eunit, cover]}]}.
+{alias, [{test, [format, lint, xref, dialyzer, eunit, cover]}]}.


### PR DESCRIPTION
This PR fixes the configuration file for rebar3_lint (elvis.config) because some days ago it changed the way it is configured.

I disabled 2 rules (atom_naming_convention and macro_names) because they started to be triggered after this update. The code it detects to be bad is 9 years old so looks like it was because of the recent changes. 