### PR TITLE
[RTI-17466] Maybe recycle gun client

### DIFF
--- a/.buildkite/pipelines/dinerl-pr-builder/start.yml
+++ b/.buildkite/pipelines/dinerl-pr-builder/start.yml
@@ -15,5 +15,5 @@
           user: 2000:2000
           propagate-environment: true
           propagate-aws-auth-tokens: true
-          mount-ssh-agent: true
+          mount-ssh-agent: /home/buildkite-agent
           workdir: /app

--- a/.buildkite/pipelines/dinerl-pr-builder/start.yml
+++ b/.buildkite/pipelines/dinerl-pr-builder/start.yml
@@ -1,6 +1,7 @@
 - label: 'Test Build'
   command:
-    - if [ ! -z "$MERGE_BRANCH" ]; then git merge $MERGE_BRANCH -m "merging $MERGE_BRANCH"; fi
+    - git fetch --unshallow origin $MERGE_BRANCH || git fetch origin $MERGE_BRANCH
+    - if [ ! -z "$MERGE_BRANCH" ]; then git merge -v FETCH_HEAD -m "merging $MERGE_BRANCH"; fi
     - rebar3 plugins upgrade rebar3_format
     - rebar3 format --verify
     - rebar3 dialyzer || true

--- a/src/dynamodb.erl
+++ b/src/dynamodb.erl
@@ -105,6 +105,8 @@ submit(Host, Headers, Body, Timeout, Zone) when is_list(Host) ->
                                    result,
                                    {endpoint, list_to_atom(Host)},
                                    {result, error}]),
+            %% maybe drop the gun client so the next request opens a fresh connection
+            maybe_recycle_gun_client(Worker, Reason),
             {error, unknown, Reason};
         Other ->
             dinerl_util:increment([dinerl,
@@ -115,3 +117,19 @@ submit(Host, Headers, Body, Timeout, Zone) when is_list(Host) ->
                                    {result, unknown}]),
             {error, response, Other}
     end.
+
+    maybe_recycle_gun_client(Worker, connect_timeout) when is_pid(Worker) ->
+        try
+            case ehttpc:get_state(Worker) of
+                #{client := Client} when is_pid(Client) ->
+                    dinerl_util:increment([dinerl, dynamodb, gun_recycle,
+                                           {reason, connect_timeout}]),
+                    exit(Client, kill);
+                _ ->
+                    ok
+            end
+        catch
+            _:_ -> ok
+        end;
+maybe_recycle_gun_client(_Worker, _Reason) ->
+    ok.

--- a/src/dynamodb.erl
+++ b/src/dynamodb.erl
@@ -118,18 +118,18 @@ submit(Host, Headers, Body, Timeout, Zone) when is_list(Host) ->
             {error, response, Other}
     end.
 
-    maybe_recycle_gun_client(Worker, connect_timeout) when is_pid(Worker) ->
-        try
-            case ehttpc:get_state(Worker) of
-                #{client := Client} when is_pid(Client) ->
-                    dinerl_util:increment([dinerl, dynamodb, gun_recycle,
-                                           {reason, connect_timeout}]),
-                    exit(Client, kill);
-                _ ->
-                    ok
-            end
-        catch
-            _:_ -> ok
-        end;
+maybe_recycle_gun_client(Worker, connect_timeout) ->
+    try
+        case ehttpc:get_state(Worker) of
+            #{client := Client, gun_state := down} when is_pid(Client) ->
+                dinerl_util:increment([dinerl, dynamodb, gun_recycle, {reason, connect_timeout}]),
+                exit(Client, kill);
+            _ ->
+                ok
+        end
+    catch
+        _:_ ->
+            ok
+    end;
 maybe_recycle_gun_client(_Worker, _Reason) ->
     ok.


### PR DESCRIPTION
This makes it so after we've waited for gun to be up, we exit its process to reconnect on timeout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Killing gun client PIDs affects live HTTP connection pooling for DynamoDB; mis-timed exits could add latency, but behavior is gated on connect_timeout and gun down state.
> 
> **Overview**
> **DynamoDB HTTP errors** now call `maybe_recycle_gun_client/2` on the `{error, Reason}` path. When `Reason` is `connect_timeout` and `ehttpc:get_state/1` shows `gun_state := down`, the underlying gun client process is killed (with a `gun_recycle` metric) so the next call can open a new connection instead of reusing a stuck client.
> 
> **Buildkite PR builder** (`start.yml`) fetches the merge ref (`git fetch --unshallow` / `git fetch` on `$MERGE_BRANCH`) and merges `FETCH_HEAD` with verbose logging, and sets `mount-ssh-agent` to `/home/buildkite-agent` instead of a bare `true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3614f9b39369c03e092ac37a1a879909109db545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->